### PR TITLE
allow non super users to view skill requests & filter out skill requests not generated by non super users

### DIFF
--- a/skill-tree/src/main/java/com/RDS/skilltree/apis/SkillsApi.java
+++ b/skill-tree/src/main/java/com/RDS/skilltree/apis/SkillsApi.java
@@ -14,18 +14,18 @@ import com.RDS.skilltree.viewmodels.CreateSkillViewModel;
 import com.RDS.skilltree.viewmodels.EndorsementViewModel;
 import com.RDS.skilltree.viewmodels.SkillViewModel;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("v1/skills")
-@AuthorizedRoles({UserRoleEnum.USER, UserRoleEnum.SUPERUSER})
 public class SkillsApi {
     private final SkillService skillService;
     private final EndorsementService endorsementService;
@@ -36,7 +36,6 @@ public class SkillsApi {
     }
 
     @GetMapping("/requests")
-    @AuthorizedRoles({UserRoleEnum.SUPERUSER})
     public ResponseEntity<SkillRequestsDto> getAllRequests(
             @RequestParam(value = "status", required = false) UserSkillStatusEnum status) {
         if (status != null) {

--- a/skill-tree/src/main/java/com/RDS/skilltree/apis/SkillsApi.java
+++ b/skill-tree/src/main/java/com/RDS/skilltree/apis/SkillsApi.java
@@ -14,13 +14,12 @@ import com.RDS.skilltree.viewmodels.CreateSkillViewModel;
 import com.RDS.skilltree.viewmodels.EndorsementViewModel;
 import com.RDS.skilltree.viewmodels.SkillViewModel;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Slf4j
 @RestController

--- a/skill-tree/src/main/java/com/RDS/skilltree/repositories/UserSkillRepository.java
+++ b/skill-tree/src/main/java/com/RDS/skilltree/repositories/UserSkillRepository.java
@@ -4,9 +4,17 @@ import com.RDS.skilltree.enums.UserSkillStatusEnum;
 import com.RDS.skilltree.models.UserSkills;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserSkillRepository extends JpaRepository<UserSkills, Integer> {
     List<UserSkills> findByStatus(UserSkillStatusEnum status);
 
     List<UserSkills> findByUserIdAndSkillId(String userId, Integer skillId);
+
+    @Query(
+            "SELECT us FROM UserSkills us "
+                    + "JOIN Endorsement e ON us.userId = e.endorseId "
+                    + "WHERE e.endorserId = :endorserId")
+    List<UserSkills> findUserSkillsByEndorserId(@Param("endorserId") String endorserId);
 }

--- a/skill-tree/src/main/java/com/RDS/skilltree/viewmodels/RdsUserViewModel.java
+++ b/skill-tree/src/main/java/com/RDS/skilltree/viewmodels/RdsUserViewModel.java
@@ -37,6 +37,7 @@ public class RdsUserViewModel {
         private boolean archived;
         private boolean in_discord;
         private boolean member;
+        private boolean super_user;
     }
 
     @Getter


### PR DESCRIPTION
Date: 1 September 2024
Developer Name: yash raj

## Issue Ticket Number
- #151 

## Related ticket
- #154 

## Description
- remove superuser check on `/skills` & `/skills/requests` API to allow non-superusers to create endorsements and view endorsements they created.
- for non-superusers send only the skills requests created by them from the `/skills/requests` route.

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
- [test video](https://drive.google.com/file/d/1SUC5-OppRIFaneikKL4JKk-3bhU0cc3r/view?usp=sharing)