### PR TITLE
Enhance Unit Test Coverage for Skills and endorsement API Methods

### DIFF
--- a/skill-tree/src/test/java/com/RDS/skilltree/unitTests/EndorsementsApiUnitTests.java
+++ b/skill-tree/src/test/java/com/RDS/skilltree/unitTests/EndorsementsApiUnitTests.java
@@ -1,0 +1,97 @@
+package com.RDS.skilltree.unitTests;
+
+import com.RDS.skilltree.dtos.RdsGetUserDetailsResDto;
+import com.RDS.skilltree.models.Endorsement;
+import com.RDS.skilltree.models.Skill;
+import com.RDS.skilltree.repositories.EndorsementRepository;
+import com.RDS.skilltree.services.EndorsementServiceImplementation;
+import com.RDS.skilltree.services.external.RdsService;
+import com.RDS.skilltree.viewmodels.EndorsementViewModel;
+import com.RDS.skilltree.viewmodels.RdsUserViewModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+
+public class EndorsementsApiUnitTests {
+
+    @Mock
+    private EndorsementRepository endorsementRepository;
+
+    @Mock
+    private RdsService rdsService;
+
+    @InjectMocks
+    private EndorsementServiceImplementation endorsementService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);  // Initialize mocks
+
+    }
+
+
+    @Test
+    @DisplayName("To test getAllEndorsementsBySkillId() method")
+    public void testGetAllEndorsementsBySkillId()
+    {
+        List<Endorsement> endorsements = new ArrayList<>();
+
+        Integer skillId =1;
+
+        //initializing a skill
+        Skill skill1 = new Skill();
+        skill1.setId(skillId);
+        skill1.setName("python");
+
+
+        //initializing an endorsement
+        Endorsement endorsement1 = new Endorsement();
+        endorsement1.setId(1);
+        endorsement1.setSkill(skill1);
+        endorsement1.setEndorserId("456");
+        endorsement1.setEndorseId("123");
+        endorsement1.setMessage("Please approve my endorsement for this skill");
+
+        endorsements.add(endorsement1);
+
+        RdsGetUserDetailsResDto rdsGetUserDetailsResDto1 = new RdsGetUserDetailsResDto();
+        RdsUserViewModel rdsUserViewModel1= new RdsUserViewModel();
+        rdsUserViewModel1.setId("123");
+        rdsGetUserDetailsResDto1.setUser(rdsUserViewModel1);
+
+
+        RdsGetUserDetailsResDto rdsGetUserDetailsResDto2 = new RdsGetUserDetailsResDto();
+        RdsUserViewModel rdsUserViewModel2= new RdsUserViewModel();
+        rdsUserViewModel2.setId("456");
+        rdsGetUserDetailsResDto2.setUser(rdsUserViewModel2);
+
+
+
+        //Mock behaviour
+        when(endorsementRepository.findBySkillId(skillId)).thenReturn(endorsements);
+        when(rdsService.getUserDetails(endorsement1.getEndorseId())).thenReturn(rdsGetUserDetailsResDto1);
+        when(rdsService.getUserDetails(endorsement1.getEndorserId())).thenReturn(rdsGetUserDetailsResDto2);
+
+
+        //Act
+
+        List<EndorsementViewModel> endorsmentsBySkillId = endorsementService.getAllEndorsementsBySkillId(skillId);
+
+        assert(endorsmentsBySkillId.size() == 1);
+        assertEquals("456", endorsmentsBySkillId.get(0).getEndorser().getId());
+        assertEquals("123", endorsmentsBySkillId.get(0).getEndorse().getId());
+        assertEquals("python", endorsmentsBySkillId.get(0).getSkill().getName());
+
+
+    }
+
+
+}

--- a/skill-tree/src/test/java/com/RDS/skilltree/unitTests/SkillsApiUnitTests.java
+++ b/skill-tree/src/test/java/com/RDS/skilltree/unitTests/SkillsApiUnitTests.java
@@ -1,0 +1,156 @@
+package com.RDS.skilltree.unitTests;
+
+import com.RDS.skilltree.dtos.RdsGetUserDetailsResDto;
+import com.RDS.skilltree.enums.SkillTypeEnum;
+import com.RDS.skilltree.exceptions.SkillAlreadyExistsException;
+import com.RDS.skilltree.models.JwtUser;
+import com.RDS.skilltree.models.Skill;
+import com.RDS.skilltree.repositories.SkillRepository;
+import com.RDS.skilltree.services.SkillService;
+import com.RDS.skilltree.services.SkillServiceImplementation;
+import com.RDS.skilltree.services.external.RdsService;
+import com.RDS.skilltree.viewmodels.CreateSkillViewModel;
+import com.RDS.skilltree.viewmodels.RdsUserViewModel;
+import com.RDS.skilltree.viewmodels.SkillViewModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class SkillsApiUnitTests {
+
+    @Mock
+    private SkillRepository skillRepository;
+
+    @Mock
+    private RdsService rdsService;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @Mock
+    private Authentication authentication;
+
+    @InjectMocks
+    private SkillServiceImplementation skillService; // Class containing the getAll() method
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);  // Initialize mocks
+    }
+
+    @Test
+    @DisplayName("Test the getAll() method returns all the created skills, where the skills return in a sorted order based on skill-Id.")
+    public void getAllSkillsHappyFlow()
+    {
+
+        Skill skill1 = new Skill();
+        skill1.setId(1);
+        skill1.setName("Java");
+        skill1.setType(SkillTypeEnum.ATOMIC);
+
+        Skill skill2 = new Skill();
+        skill2.setId(2);
+        skill2.setName("Spring Boot");
+        skill2.setType(SkillTypeEnum.ATOMIC);
+
+
+        // Mock the repository's behavior
+        when(skillRepository.findAll()).thenReturn(Arrays.asList(skill1, skill2));
+
+        // Act: Call the method to be tested
+        List<SkillViewModel> result = skillService.getAll();
+
+        // Assert: Verify the result
+        assertEquals(2, result.size());
+        assertEquals("Java", result.get(0).getName());
+        assertEquals("Spring Boot", result.get(1).getName());
+
+        // Verify that the repository was called once
+        verify(skillRepository, times(1)).findAll();
+    }
+
+
+    @Test
+    public void testCreateSkill_Success() {
+        // Arrange: Mock request and setup mocks
+        CreateSkillViewModel createSkill = new CreateSkillViewModel();
+        createSkill.setName("python");
+        createSkill.setType(SkillTypeEnum.ATOMIC);
+
+        RdsUserViewModel viewModel = new RdsUserViewModel();
+        viewModel.setId("123");
+
+        RdsGetUserDetailsResDto userDetails = new RdsGetUserDetailsResDto();
+        userDetails.setUser(viewModel);
+
+
+        Skill skillEntity = new Skill();
+        skillEntity.setId(5);
+        skillEntity.setName("python");
+        skillEntity.setType(SkillTypeEnum.ATOMIC);
+        skillEntity.setCreatedBy(userDetails.getUser().getId());
+
+        SkillViewModel expectedViewModel = SkillViewModel.toViewModel(skillEntity);
+
+        // Mock behavior
+        when(skillRepository.existsByName("python")).thenReturn(false);
+
+        when(skillRepository.saveAndFlush(any(Skill.class))).thenReturn(skillEntity);
+
+        // Act: Call the method
+        SkillViewModel actualViewModel = skillService.create(createSkill);
+
+        // Assert: Verify the result
+        assertNotNull(actualViewModel);
+        assertEquals(expectedViewModel.getId(), actualViewModel.getId());
+        assertEquals(expectedViewModel.getName(), actualViewModel.getName());
+        assertEquals(expectedViewModel.getType(), actualViewModel.getType());
+
+        // Verify that the repository and service were called correctly
+        verify(skillRepository, times(1)).existsByName("python");
+        verify(skillRepository, times(1)).saveAndFlush(any(Skill.class));
+
+    }
+
+
+    @Test
+    public void testCreateSkill_AlreadyExists() {
+        // Arrange
+        CreateSkillViewModel createSkill = new CreateSkillViewModel();
+        createSkill.setName("python");
+        createSkill.setType(SkillTypeEnum.ATOMIC);
+
+        // Mock behavior
+        when(skillRepository.existsByName("python")).thenReturn(true);
+
+        // Act & Assert: Verify that exception is thrown
+        SkillAlreadyExistsException exception = assertThrows(
+                SkillAlreadyExistsException.class,
+                () -> skillService.create(createSkill),
+                "Skill with name "+createSkill.getName()+"already exists"
+        );
+
+        assertEquals("Skill with name python already exists", exception.getMessage());
+
+        // Verify repository was called once, but saveAndFlush wasn't called
+        verify(skillRepository, times(1)).existsByName("python");
+        verify(skillRepository, never()).saveAndFlush(any(Skill.class));
+    }
+
+
+
+
+}


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 25 10 2024
<!--Developer Name Here-->
Developer Name: Dheeraj Chepuri

---

## Issue Ticket Number
#162 
#163 
#164 
#165 

## Description

This pull request improves unit test coverage for the  getAll(),create(),approveRejectSkillRequest() and getAllEndorsementsBySkillId in skillServiceImplementation and EndorsementServiceImplementation classes within the Spring Boot application.

### Documentation Updated?

- [ ] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [ ] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![image](https://github.com/user-attachments/assets/25cff729-02be-4724-a896-ba70bac2eaa2)


</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
