### PR TITLE
Test: Integration Test for POST /v1/skills/requests/{skillId}/action

### DIFF
--- a/skill-tree/src/test/java/com/RDS/skilltree/skills/SkillRequestActionIntegrationTest.java
+++ b/skill-tree/src/test/java/com/RDS/skilltree/skills/SkillRequestActionIntegrationTest.java
@@ -1,0 +1,200 @@
+package com.RDS.skilltree.skills;
+
+import com.RDS.skilltree.dtos.RdsGetUserDetailsResDto;
+import com.RDS.skilltree.enums.SkillTypeEnum;
+import com.RDS.skilltree.enums.UserSkillStatusEnum;
+import com.RDS.skilltree.models.Skill;
+import com.RDS.skilltree.models.UserSkills;
+import com.RDS.skilltree.repositories.SkillRepository;
+import com.RDS.skilltree.repositories.UserSkillRepository;
+import com.RDS.skilltree.services.external.RdsService;
+import com.RDS.skilltree.utils.JWTUtils;
+import com.RDS.skilltree.viewmodels.RdsUserViewModel;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import utils.WithCustomMockUser;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class SkillRequestActionIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private UserSkillRepository userSkillRepository;
+    @Autowired
+    private SkillRepository skillRepository;
+    @MockBean
+    private RdsService rdsService;
+    @MockBean
+    private JWTUtils jwtUtils;
+    @Autowired
+    private ObjectMapper objectMapper;
+    private Skill skill;
+    private final String baseRoute = "/v1/skills/requests";
+
+    @BeforeEach
+    void setUp() {
+        // Clean up repositories
+        skillRepository.deleteAll();
+        userSkillRepository.deleteAll();
+
+        // Setup super-user detail
+        RdsUserViewModel superUser = new RdsUserViewModel();
+        superUser.setId("super-user-id");
+        RdsUserViewModel.Roles roles = new RdsUserViewModel.Roles();
+        roles.setSuper_user(true);
+        superUser.setRoles(roles);
+
+        RdsGetUserDetailsResDto superUserDetails = new RdsGetUserDetailsResDto();
+        superUserDetails.setUser(superUser);
+
+        // Setup mock skill
+        skill = new Skill();
+        skill.setName("Java");
+        skill.setType(SkillTypeEnum.ATOMIC);
+        skill.setCreatedBy("super-user-id");
+        skill = skillRepository.save(skill);
+
+        // Setup mock user-skill
+        UserSkills userSkill = new UserSkills();
+        userSkill.setSkill(skill);
+        userSkill.setUserId("test-user-id");
+        userSkill.setStatus(UserSkillStatusEnum.PENDING);
+        userSkillRepository.save(userSkill);
+
+        // Setup RDS service mock responses
+        when(rdsService.getUserDetails("super-user-id")).thenReturn(superUserDetails);
+
+        // Mock JWTUtils to bypass actual JWT verification
+        Claims mockClaims = mock(Claims.class);
+        when(mockClaims.get("userId", String.class)).thenReturn("super-user-id");
+        when(jwtUtils.validateToken(anyString())).thenReturn(mockClaims);
+    }
+
+    @Test
+    @DisplayName("Happy flow - Super user can approve a skill request")
+    @WithCustomMockUser(username = "super-user-id", authorities = {"SUPERUSER"})
+    public void approveSkillRequest_validRequest_shouldApproveSkillRequest() throws Exception {
+        String requestBody = """
+                {
+                    "endorseId": "test-user-id",
+                    "action": "APPROVED"
+                }
+                """;
+
+        mockMvc.perform(MockMvcRequestBuilders.post(baseRoute + "/" + skill.getId() + "/action")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.valueOf(requestBody)))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("approved"));
+
+        // Verify the status was updated in database
+        UserSkills updatedUserSkill = userSkillRepository.findByUserIdAndSkillId("test-user-id", skill.getId()).get(0);
+        Assertions.assertEquals(UserSkillStatusEnum.APPROVED, updatedUserSkill.getStatus());
+    }
+
+    @Test
+    @DisplayName("Happy flow - Super user can reject a skill request")
+    @WithCustomMockUser(username = "super-user-id", authorities = {"SUPERUSER"})
+    public void rejectSkillRequest_validRequest_shouldRejectSkillRequest() throws Exception {
+        String requestBody = """
+                {
+                    "endorseId": "test-user-id",
+                    "action": "REJECTED"
+                }
+                """;
+
+        mockMvc.perform(MockMvcRequestBuilders.post(baseRoute + "/" + skill.getId() + "/action")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("rejected"));
+
+        // Verify the status was updatedUserSkill in database
+        UserSkills updatedUserSkill = userSkillRepository.findByUserIdAndSkillId("test-user-id", skill.getId()).get(0);
+        Assertions.assertEquals(UserSkillStatusEnum.REJECTED, updatedUserSkill.getStatus());
+    }
+
+    @Test
+    @DisplayName("Error case - Request with non-existent skill ID")
+    @WithCustomMockUser(username = "super-user-id", authorities = {"SUPERUSER"})
+    public void approveSkillRequest_NonExistentSkillId_ShouldFail() throws Exception {
+        String requestBody = """
+                {
+                    "endorseId": "test-user-id",
+                    "action": "APPROVED"
+                }
+                """;
+
+        mockMvc.perform(MockMvcRequestBuilders.post(baseRoute + "/123/action")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Error case - Request with non-existent user ID")
+    @WithCustomMockUser(username = "super-user-id", authorities = {"SUPERUSER"})
+    public void approveSkillRequest_NonExistentUserId_ShouldFail() throws Exception {
+        String requestBody = """
+                {
+                    "endorseId": "non-existent-user",
+                    "action": "APPROVED"
+                }
+                """;
+
+        mockMvc.perform(MockMvcRequestBuilders.post(baseRoute + "/" + skill.getId() + "/action")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Validation test - Missing required fields")
+    @WithCustomMockUser(username = "super-user-id", authorities = {"SUPERUSER"})
+    public void approveSkillRequest_MissingRequiredFields_ShouldFail() throws Exception {
+        String requestBody = "{}";
+
+        mockMvc.perform(MockMvcRequestBuilders.post(baseRoute + "/" + skill.getId() + "/action")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Authorization test - Non-super user cannot access endpoint")
+    @WithCustomMockUser(username = "normal-user", authorities = {"USER"})
+    public void approveSkillRequest_NonSuperUser_ShouldFail() throws Exception {
+        String requestBody = """
+                {
+                    "endorseId": "test-user-id",
+                    "action": "APPROVED"
+                }
+                """;
+
+        mockMvc.perform(MockMvcRequestBuilders.post(baseRoute + "/" + skill.getId() + "/action")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(MockMvcResultMatchers.status().isForbidden());
+    }
+}


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 19 Jan 2025
<!--Developer Name Here-->
Developer Name: Shyam Vishwakarma

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes: #170 
## Description

<!--Description of the changes made in this PR-->
- Wrote integration test for POST /v1/skills/requests/{skillId}/action

### Documentation Updated?

- [x] Yes
- [ ] No

Document: [Link](https://docs.google.com/document/d/14Ueu3LnhajBt8hXO6vfADkm7Cp0V-H4mK8mssl7Mx4w/edit?usp=sharing)

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![Screenshot 2025-01-19 184940](https://github.com/user-attachments/assets/d876deae-db8f-41ba-a4c0-e941f7f1c24f)
</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

For `SkillRequestActionIntegrationTest`:

i.
![Screenshot 2025-01-27 131151](https://github.com/user-attachments/assets/27600b7e-5327-4f7e-a121-178d185e70e2)

ii.
![Screenshot 2025-01-27 131221](https://github.com/user-attachments/assets/f4d12f21-1637-46ed-baad-28580321acfa)



</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->

- If you face any error such as `skilltreetestdb not found`, then create a test database manually in your local using `create database skilltreetestdb;` (will add this in documentation asap)