### PR TITLE
fix: update formatting of integration tests for POST /v1/skills/requests/{skillId}/action

### DIFF
--- a/skill-tree/src/test/java/com/RDS/skilltree/skills/SkillRequestActionIntegrationTest.java
+++ b/skill-tree/src/test/java/com/RDS/skilltree/skills/SkillRequestActionIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.RDS.skilltree.dtos.RdsGetUserDetailsResDto;
+import com.RDS.skilltree.dtos.SkillRequestActionRequestDto;
 import com.RDS.skilltree.enums.SkillTypeEnum;
 import com.RDS.skilltree.enums.UserSkillStatusEnum;
 import com.RDS.skilltree.models.Skill;
@@ -90,8 +91,10 @@ public class SkillRequestActionIntegrationTest {
             username = "super-user-id",
             authorities = {"SUPERUSER"})
     public void approveSkillRequest_validRequest_shouldApproveSkillRequest() throws Exception {
-        String requestBody =
-                "{" + "\"endorseId\": \"test-user-id\"," + "\"action\": \"APPROVED\"" + "}";
+        SkillRequestActionRequestDto requestDto = new SkillRequestActionRequestDto();
+        requestDto.setEndorseId("test-user-id");
+        requestDto.setAction(UserSkillStatusEnum.APPROVED);
+        String requestBody = objectMapper.writeValueAsString(requestDto);
 
         mockMvc
                 .perform(
@@ -114,8 +117,10 @@ public class SkillRequestActionIntegrationTest {
             username = "super-user-id",
             authorities = {"SUPERUSER"})
     public void rejectSkillRequest_validRequest_shouldRejectSkillRequest() throws Exception {
-        String requestBody =
-                "{" + "\"endorseId\": \"test-user-id\"," + "\"action\": \"REJECTED\"" + "}";
+        SkillRequestActionRequestDto requestDto = new SkillRequestActionRequestDto();
+        requestDto.setEndorseId("test-user-id");
+        requestDto.setAction(UserSkillStatusEnum.REJECTED);
+        String requestBody = objectMapper.writeValueAsString(requestDto);
 
         mockMvc
                 .perform(
@@ -125,7 +130,7 @@ public class SkillRequestActionIntegrationTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("rejected"));
 
-        // Verify the status was updatedUserSkill in database
+        // Verify the status was updated in database
         UserSkills updatedUserSkill =
                 userSkillRepository.findByUserIdAndSkillId("test-user-id", skill.getId()).get(0);
         Assertions.assertEquals(UserSkillStatusEnum.REJECTED, updatedUserSkill.getStatus());
@@ -137,8 +142,10 @@ public class SkillRequestActionIntegrationTest {
             username = "super-user-id",
             authorities = {"SUPERUSER"})
     public void approveSkillRequest_NonExistentSkillId_ShouldFail() throws Exception {
-        String requestBody =
-                "{" + "\"endorseId\": \"test-user-id\"," + "\"action\": \"APPROVED\"" + "}";
+        SkillRequestActionRequestDto requestDto = new SkillRequestActionRequestDto();
+        requestDto.setEndorseId("test-user-id");
+        requestDto.setAction(UserSkillStatusEnum.APPROVED);
+        String requestBody = objectMapper.writeValueAsString(requestDto);
 
         mockMvc
                 .perform(
@@ -154,8 +161,10 @@ public class SkillRequestActionIntegrationTest {
             username = "super-user-id",
             authorities = {"SUPERUSER"})
     public void approveSkillRequest_NonExistentUserId_ShouldFail() throws Exception {
-        String requestBody =
-                "{" + "\"endorseId\": \"non-existent-user\"," + "\"action\": \"APPROVED\"" + "}";
+        SkillRequestActionRequestDto requestDto = new SkillRequestActionRequestDto();
+        requestDto.setEndorseId("non-existent-user");
+        requestDto.setAction(UserSkillStatusEnum.APPROVED);
+        String requestBody = objectMapper.writeValueAsString(requestDto);
 
         mockMvc
                 .perform(
@@ -187,8 +196,10 @@ public class SkillRequestActionIntegrationTest {
             username = "normal-user",
             authorities = {"USER"})
     public void approveSkillRequest_NonSuperUser_ShouldFail() throws Exception {
-        String requestBody =
-                "{" + "\"endorseId\": \"test-user-id\"," + "\"action\": \"APPROVED\"" + "}";
+        SkillRequestActionRequestDto requestDto = new SkillRequestActionRequestDto();
+        requestDto.setEndorseId("test-user-id");
+        requestDto.setAction(UserSkillStatusEnum.APPROVED);
+        String requestBody = objectMapper.writeValueAsString(requestDto);
 
         mockMvc
                 .perform(


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 01 April 2025
<!--Developer Name Here-->
Developer Name: @Shyam-Vishwakarma 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes: #187 
## Description

<!--Description of the changes made in this PR-->
- Updated the formatting of the string literal of `request-body` for the tests.

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>
BUILD SUCCESS:

![{D6984C31-86A2-4203-9B0D-8A02C80D5974}](https://github.com/user-attachments/assets/439c1d11-937e-4efb-adae-81682a063b33)


<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>
- Test coverage for only tests written for POST /v1/skills/requests/{skillId}/action

![{29C378A4-1933-411A-803B-798E5191EA79}](https://github.com/user-attachments/assets/31cc97d1-180d-4228-a653-5e38c5c62b58)



</details>

<details>
<summary>Screenshot 2</summary>

- Test coverage for all tests
![{367CEC00-D9B1-42FC-BA4B-E0645705AF30}](https://github.com/user-attachments/assets/6fda7e3a-6d7c-4ff4-a96f-8b31db5d660e)



<!-- Attach your screenshots here👇-->
</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
- If you face any error such as `skilltreetestdb not found`, then create a test database manually in your local using `create database skilltreetestdb;` 
- To check if the codebase is formatted, you can use `mvn spotless:check`